### PR TITLE
Move PRD/Spec headers out of cards and reposition action buttons

### DIFF
--- a/src/components/DocumentActionBar.tsx
+++ b/src/components/DocumentActionBar.tsx
@@ -5,6 +5,7 @@ import type { PaneMode } from "../types";
 interface DocumentActionBarProps {
   mode: PaneMode;
   loadLabel: string;
+  showModeButtons?: boolean;
   onLoad: () => void;
   onModeChange: (mode: PaneMode) => void;
 }
@@ -12,16 +13,26 @@ interface DocumentActionBarProps {
 export const DocumentActionBar = memo(function DocumentActionBar({
   mode,
   loadLabel,
+  showModeButtons = true,
   onLoad,
   onModeChange
 }: DocumentActionBarProps) {
   return (
     <div className="inline-flex flex-wrap items-center rounded-full border border-[var(--border-soft)] bg-white/4 p-1">
-      <ModeButton
-        active={mode === "preview"}
-        label="Preview"
-        onClick={() => onModeChange("preview")}
-      />
+      {showModeButtons ? (
+        <ModeButton
+          active={mode === "preview"}
+          label="Preview"
+          onClick={() => onModeChange("preview")}
+        />
+      ) : null}
+      {showModeButtons ? (
+        <ModeButton
+          active={mode === "edit"}
+          label="Edit"
+          onClick={() => onModeChange("edit")}
+        />
+      ) : null}
       <button
         className="rounded-full bg-white/7 px-4 py-2 text-sm font-medium text-[var(--text-main)] transition hover:-translate-y-0.5 hover:bg-white/10"
         onClick={onLoad}
@@ -29,11 +40,6 @@ export const DocumentActionBar = memo(function DocumentActionBar({
       >
         {loadLabel}
       </button>
-      <ModeButton
-        active={mode === "edit"}
-        label="Edit"
-        onClick={() => onModeChange("edit")}
-      />
     </div>
   );
 });

--- a/src/components/DocumentEmptyState.tsx
+++ b/src/components/DocumentEmptyState.tsx
@@ -1,56 +1,20 @@
 import { memo, type ReactNode } from "react";
 
-import { DocumentActionBar } from "./DocumentActionBar";
-import type { PaneMode } from "../types";
-
 interface DocumentEmptyStateProps {
-  eyebrow: string;
-  title: string;
-  mode: PaneMode;
-  loadLabel: string;
   heading: string;
   description: string;
   icon: ReactNode;
   children?: ReactNode;
-  headerAction?: ReactNode;
-  onLoad: () => void;
-  onModeChange: (mode: PaneMode) => void;
 }
 
 export const DocumentEmptyState = memo(function DocumentEmptyState({
-  eyebrow,
-  title,
-  mode,
-  loadLabel,
   heading,
   description,
   icon,
-  children,
-  headerAction,
-  onLoad,
-  onModeChange
+  children
 }: DocumentEmptyStateProps) {
   return (
     <article className="flex min-h-0 flex-col gap-4 rounded-[1.2rem] border border-[var(--border-soft)] bg-[var(--bg-surface)] p-4">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0">
-          <p className="mb-1 text-[0.72rem] font-extrabold uppercase tracking-[0.12em] text-[var(--accent-2)]">
-            {eyebrow}
-          </p>
-          <h2 className="m-0 truncate text-lg font-semibold text-[var(--text-main)]">{title}</h2>
-        </div>
-
-        <div className="flex flex-wrap items-center justify-end gap-3">
-          <DocumentActionBar
-            loadLabel={loadLabel}
-            mode={mode}
-            onLoad={onLoad}
-            onModeChange={onModeChange}
-          />
-          {headerAction}
-        </div>
-      </div>
-
       <div className="flex min-h-0 flex-1 flex-col justify-start gap-4 overflow-auto rounded-[1rem] border border-dashed border-[var(--border-soft)] bg-black/10 p-5">
         <div className="flex items-start gap-2.5">
           <span className="mt-1 shrink-0 text-[var(--accent-2)]">{icon}</span>

--- a/src/components/DocumentPane.tsx
+++ b/src/components/DocumentPane.tsx
@@ -1,54 +1,32 @@
 import { memo, type ChangeEvent, type ReactNode } from "react";
 
-import { DocumentActionBar } from "./DocumentActionBar";
 import { MarkdownDocument } from "./MarkdownDocument";
 import type { PaneMode } from "../types";
 
 interface DocumentPaneProps {
-  eyebrow: string;
-  title: string;
   content: string;
   mode: PaneMode;
-  loadLabel: string;
-  headerAction?: ReactNode;
-  onModeChange: (mode: PaneMode) => void;
+  className?: string;
+  children?: ReactNode;
   onChange: (value: string) => void;
-  onLoad: () => void;
   onSelect?: (event: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 export const DocumentPane = memo(function DocumentPane({
-  eyebrow,
-  title,
   content,
   mode,
-  loadLabel,
-  headerAction,
-  onModeChange,
+  className,
+  children,
   onChange,
-  onLoad,
   onSelect
 }: DocumentPaneProps) {
   return (
-    <article className="flex min-h-0 flex-col gap-4 rounded-[1.2rem] border border-[var(--border-soft)] bg-[var(--bg-surface)] p-4">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0">
-          <p className="mb-1 text-[0.72rem] font-extrabold uppercase tracking-[0.12em] text-[var(--accent-2)]">
-            {eyebrow}
-          </p>
-          <h2 className="m-0 truncate text-lg font-semibold text-[var(--text-main)]">{title}</h2>
-        </div>
-
-        <div className="flex flex-wrap items-center justify-end gap-3">
-          <DocumentActionBar
-            loadLabel={loadLabel}
-            mode={mode}
-            onLoad={onLoad}
-            onModeChange={onModeChange}
-          />
-          {headerAction}
-        </div>
-      </div>
+    <article
+      className={`flex min-h-0 flex-col gap-4 rounded-[1.2rem] border border-[var(--border-soft)] bg-[var(--bg-surface)] p-4 ${
+        className ?? ""
+      }`}
+    >
+      {children}
 
       {mode === "preview" ? (
         <div className="min-h-0 overflow-auto pr-1">

--- a/src/components/MainWorkspace.tsx
+++ b/src/components/MainWorkspace.tsx
@@ -4,6 +4,7 @@ import {
 } from "iconoir-react";
 import { memo, useEffect, useMemo, type ChangeEvent } from "react";
 
+import { DocumentActionBar } from "./DocumentActionBar";
 import { DocumentEmptyState } from "./DocumentEmptyState";
 import { DocumentPane } from "./DocumentPane";
 import { ExecutionPanel } from "./ExecutionPanel";
@@ -158,70 +159,80 @@ export const MainWorkspace = memo(function MainWorkspace({
 
       {activeTab === "review" ? (
         <div className="grid h-full min-h-0 gap-4 p-4 grid-rows-[minmax(0,1fr)_minmax(0,1fr)] xl:grid-cols-2 xl:grid-rows-1">
-          {showPrdEmptyState ? (
-            <DocumentEmptyState
-              description="Load an existing PRD or switch to Edit to draft one manually before generating a spec."
-              eyebrow="Source PRD"
-              heading="No PRD file detected"
-              icon={<FileNotFound className="size-6" />}
-              loadLabel="Load PRD"
-              mode={prdPaneMode}
-              onLoad={onLoadPrd}
-              onModeChange={onPrdPaneModeChange}
-              title={displayPrdPath || "PRD.md"}
-            />
-          ) : (
-            <DocumentPane
-              content={prdContent}
-              eyebrow="Source PRD"
-              loadLabel="Load PRD"
-              mode={prdPaneMode}
-              onChange={onPrdContentChange}
-              onLoad={onLoadPrd}
-              onModeChange={onPrdPaneModeChange}
-              title={displayPrdPath || "PRD.md"}
-            />
-          )}
-          {hasSpecContent || !showSpecPreviewState ? (
-            <DocumentPane
-              content={specContent}
-              eyebrow="Technical Spec"
-              headerAction={approveSpecButton}
-              loadLabel="Load Spec"
-              mode={specPaneMode}
-              onChange={onSpecContentChange}
-              onLoad={onLoadSpec}
-              onModeChange={onSpecPaneModeChange}
-              onSelect={onSpecSelect}
-              title={displaySpecPath || "spec.md"}
-            />
-          ) : !hasPrdContent ? (
-            <DocumentEmptyState
-              description="Load or draft a PRD first if you want SpecForge to generate a technical spec. You can still load an existing spec at any time."
-              eyebrow="Technical Spec"
-              heading="PRD required before generation"
-              icon={<FileNotFound className="size-6" />}
-              loadLabel="Load Spec"
-              mode={specPaneMode}
-              onLoad={onLoadSpec}
-              onModeChange={onSpecPaneModeChange}
-              title={displaySpecPath || "spec.md"}
-            />
-          ) : (
-            <SpecEmptyState
-              canGenerate={canGenerateSpec}
-              error={specGenerationError}
-              helperText={specGenerationHelperText}
-              isGenerating={isGeneratingSpec}
-              mode={specPaneMode}
-              onGenerate={onGenerateSpec}
-              onLoad={onLoadSpec}
-              onModeChange={onSpecPaneModeChange}
-              onPromptChange={onSpecGenerationPromptChange}
-              prompt={specGenerationPrompt}
-              title={displaySpecPath || "spec.md"}
-            />
-          )}
+          <section className="flex min-h-0 flex-col gap-3">
+            <div className="flex flex-wrap items-start justify-between gap-3 px-1">
+              <div className="min-w-0">
+                <h2 className="m-0 text-sm font-extrabold uppercase tracking-[0.12em] text-[var(--accent-2)]">
+                  PRD (Product Requirements Document)
+                </h2>
+                <p className="m-0 truncate pt-1 text-lg font-semibold text-[var(--text-main)]">
+                  {displayPrdPath || "PRD.md"}
+                </p>
+              </div>
+              <DocumentActionBar
+                loadLabel="Load PRD"
+                mode={prdPaneMode}
+                onLoad={onLoadPrd}
+                onModeChange={onPrdPaneModeChange}
+              />
+            </div>
+            {showPrdEmptyState ? (
+              <DocumentEmptyState
+                description="Load an existing PRD or switch to Edit to draft one manually before generating a spec."
+                heading="No PRD file detected"
+                icon={<FileNotFound className="size-6" />}
+              />
+            ) : (
+              <DocumentPane content={prdContent} mode={prdPaneMode} onChange={onPrdContentChange} />
+            )}
+          </section>
+
+          <section className="flex min-h-0 flex-col gap-3">
+            <div className="flex flex-wrap items-start justify-between gap-3 px-1">
+              <div className="min-w-0">
+                <h2 className="m-0 text-sm font-extrabold uppercase tracking-[0.12em] text-[var(--accent-2)]">
+                  Spec (Technical Specification)
+                </h2>
+                <p className="m-0 truncate pt-1 text-lg font-semibold text-[var(--text-main)]">
+                  {displaySpecPath || "spec.md"}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center justify-end gap-3">
+                <DocumentActionBar
+                  loadLabel="Load Spec"
+                  mode={specPaneMode}
+                  onLoad={onLoadSpec}
+                  onModeChange={onSpecPaneModeChange}
+                  showModeButtons={hasSpecContent || !showSpecPreviewState}
+                />
+                {approveSpecButton}
+              </div>
+            </div>
+            {hasSpecContent || !showSpecPreviewState ? (
+              <DocumentPane
+                content={specContent}
+                mode={specPaneMode}
+                onChange={onSpecContentChange}
+                onSelect={onSpecSelect}
+              />
+            ) : !hasPrdContent ? (
+              <DocumentEmptyState
+                description="Load or draft a PRD first if you want SpecForge to generate a technical spec. You can still load an existing spec at any time."
+                heading="PRD required before generation"
+                icon={<FileNotFound className="size-6" />}
+              />
+            ) : (
+              <SpecEmptyState
+                canGenerate={canGenerateSpec}
+                error={specGenerationError}
+                helperText={specGenerationHelperText}
+                isGenerating={isGeneratingSpec}
+                onGenerate={onGenerateSpec}
+                onPromptChange={onSpecGenerationPromptChange}
+                prompt={specGenerationPrompt}
+              />
+            )}
+          </section>
         </div>
       ) : activeTab === "execute" ? (
         <div className="h-full min-h-0 p-4">

--- a/src/components/SpecEmptyState.tsx
+++ b/src/components/SpecEmptyState.tsx
@@ -2,46 +2,31 @@ import { Spark } from "iconoir-react";
 import { memo } from "react";
 
 import { DocumentEmptyState } from "./DocumentEmptyState";
-import type { PaneMode } from "../types";
 
 interface SpecEmptyStateProps {
-  title: string;
   prompt: string;
   error: string;
   helperText: string;
   isGenerating: boolean;
   canGenerate: boolean;
-  mode: PaneMode;
-  onLoad: () => void;
-  onModeChange: (mode: PaneMode) => void;
   onPromptChange: (value: string) => void;
   onGenerate: () => void;
 }
 
 export const SpecEmptyState = memo(function SpecEmptyState({
-  title,
   prompt,
   error,
   helperText,
   isGenerating,
   canGenerate,
-  mode,
-  onLoad,
-  onModeChange,
   onPromptChange,
   onGenerate
 }: SpecEmptyStateProps) {
   return (
     <DocumentEmptyState
       description="Load an existing spec or use the current PRD plus a short brief to draft a fresh technical specification for this workspace."
-      eyebrow="Technical Spec"
       heading="No spec file detected"
       icon={<Spark className="size-6" />}
-      loadLabel="Load Spec"
-      mode={mode}
-      onLoad={onLoad}
-      onModeChange={onModeChange}
-      title={title}
     >
         <textarea
           className="min-h-[10rem] w-full flex-none resize-none rounded-[1rem] border border-[var(--border-soft)] bg-black/20 px-4 py-4 font-[var(--font-mono)] text-[15px] leading-6 text-[var(--text-main)] outline-none transition placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]"


### PR DESCRIPTION
### Motivation
- Align the review workspace with the requested UI: show PRD/spec titles and action buttons outside the document cards, remove in-card header controls, and simplify the technical spec empty state.
- Ensure the `Load` button appears to the right of mode toggles for populated documents and that the PRD and Spec labels display the requested names.

### Description
- Moved PRD and Spec headings and file paths out of the document cards and placed their action controls beside the titles in the review layout (`src/components/MainWorkspace.tsx`).
- Extracted header/action rendering out of the shared pane components by removing embedded eyebrow/title/action UI from `DocumentPane` and `DocumentEmptyState` and rendering children inside the cards instead (`src/components/DocumentPane.tsx`, `src/components/DocumentEmptyState.tsx`).
- Added a `showModeButtons` flag to `DocumentActionBar` to control whether the `Preview`/`Edit` toggles are shown and reordered the controls so `Preview` and `Edit` appear before `Load` (`src/components/DocumentActionBar.tsx`).
- Simplified the spec empty flow by removing in-card mode/load props and leaving only the prompt and a `Generate Spec` CTA within the empty card (`src/components/SpecEmptyState.tsx`).

### Testing
- Built the frontend with `bun run build`, which ran `tsc` and produced a successful production bundle (build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ac16037483268b5034272eb83b8f)